### PR TITLE
Fix: Use ttkstyle for welcome_frame background

### DIFF
--- a/guaralabs-pdf.py
+++ b/guaralabs-pdf.py
@@ -2061,7 +2061,7 @@ def show_welcome_panel():
     """Exibe o painel de boas-vindas no frame de opções."""
     clear_options_frame()
     # Fundo do welcome frame em Luz Pura da Lua
-    welcome_frame = ttkb.Frame(options_frame, background=COLOR_MOON_LIGHT)
+    welcome_frame = ttkb.Frame(options_frame, style='GuaraFrameLight.TFrame')
     welcome_frame.pack(expand=True, fill="both")
     # Texto em Dark Earth (marrom escuro)
     welcome_label = ttkb.Label(


### PR DESCRIPTION
The ttkb.Frame widget in the show_welcome_panel function was instantiated with the `background` option, which is not supported and caused a _tkinter.TclError.

This commit fixes the error by applying an existing ttkstyle, 'GuaraFrameLight.TFrame', which is already configured with the desired background color (COLOR_MOON_LIGHT). This is the standard way to style ttkbootstrap widgets.